### PR TITLE
iocs: load autosave db from its correct location

### DIFF
--- a/iocs/tlbc2IOC/iocBoot/ioctlbc2/autosave.cmd
+++ b/iocs/tlbc2IOC/iocBoot/ioctlbc2/autosave.cmd
@@ -11,7 +11,7 @@ save_restoreSet_SeqPeriodInSeconds(300)
 
 set_savefile_path("C:/ProgramData/ADTLBC2", "autosave")
 
-dbLoadRecords("db/save_restoreStatus.db", "P=$(PREFIX)")
+dbLoadRecords("$(AUTOSAVE)/db/save_restoreStatus.db", "P=$(PREFIX)")
 
 set_pass0_restoreFile("$(AUTOSAVE_PREFIX).sav")
 set_pass1_restoreFile("$(AUTOSAVE_PREFIX).sav")


### PR DESCRIPTION
Autosave database should not be read from a relative path, but rather the absolute path specified by AUTOSAVE.

Alternatively, we could configure tlbc2IOC to install required database from $AUTOSAVE, and specify the path relative to $TOP. However, that's not done for other database dependencies, and it is not the practice in other example IOCs. So, let's stick with conventional direct dependence on the installed artifact for now.

Fixes: 2b55e00 (iocs: add missing load database save_restoreStatus.db, 2025-07-18)