### PR TITLE
Release v1.1.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,10 @@
 ADTLBC2 Release Notes
 =====================
 
+Unreleased
+----------
+
+
 v1.1.0 (October 8, 2025)
 ----------
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,18 @@
 ADTLBC2 Release Notes
 =====================
 
+v1.1.0 (October 8, 2025)
+----------
+
+* Add tracing to handle_tlbc2_err
+* Fix application of autosave for ROI:
+    - Fix typo to actually configure MinY
+    - Correct the restore order for Size{X,Y} and Min{X,Y}
+* Fulfill requirements of AreaDetector guidelines:
+    - ArrayCallbacks PV is now checked before forwarding arrays
+    - Timestamps are assigned to array as attributes
+* Autosave status PVs are now loaded in the iocsh template
+
 v1.0.0 (May 6, 2025)
 ----------
 


### PR DESCRIPTION
The appropriate release notes are created retroactively as we haven't done in their corresponding commits.

To make this process easier for future releases, I've added an "unreleased header" to the document. The idea is fill that section until it is release time, when a new header with the date will simply push the unreleased one upwards. This way, we always have somewhere to place new entries to the changelog.